### PR TITLE
feat: handle sizes dynamically

### DIFF
--- a/src/theme/avatar.ts
+++ b/src/theme/avatar.ts
@@ -1,38 +1,38 @@
 export default {
   slots: {
-    root: 'inline-flex items-center justify-center shrink-0 select-none overflow-hidden rounded-full align-middle bg-gray-100 dark:bg-gray-800',
-    image: 'h-full w-full rounded-[inherit] object-cover',
-    fallback: 'font-medium leading-none text-gray-500 dark:text-gray-400 truncate',
-    icon: 'text-gray-500 dark:text-gray-400 shrink-0'
+    root: '@container/avatar inline-flex items-center justify-center shrink-0 select-none overflow-hidden rounded-full align-middle bg-gray-100 dark:bg-gray-800',
+    image: 'text-[50cqi] h-full w-full rounded-[inherit] object-cover',
+    fallback: 'text-[50cqi] font-medium leading-none text-gray-500 dark:text-gray-400 truncate',
+    icon: 'text-[50cqi] text-gray-500 dark:text-gray-400 shrink-0'
   },
   variants: {
     size: {
       '3xs': {
-        root: 'size-4 text-[8px]'
+        root: 'size-4'
       },
       '2xs': {
-        root: 'size-5 text-[10px]'
+        root: 'size-5'
       },
       xs: {
-        root: 'size-6 text-xs'
+        root: 'size-6'
       },
       sm: {
-        root: 'size-7 text-sm'
+        root: 'size-7'
       },
       md: {
-        root: 'size-8 text-base'
+        root: 'size-8'
       },
       lg: {
-        root: 'size-9 text-lg'
+        root: 'size-9'
       },
       xl: {
-        root: 'size-10 text-xl'
+        root: 'size-10'
       },
       '2xl': {
-        root: 'size-11 text-[22px]'
+        root: 'size-11'
       },
       '3xl': {
-        root: 'size-12 text-2xl'
+        root: 'size-12'
       }
     }
   },


### PR DESCRIPTION
## ⚠️ Highly experimental PR!

The main reason why I'm opening this draft PR is to use it as a personal backlog.
What I'm aiming at with this is to both expand all the sizing declarations as well as handling them dynamically within each component.

In my point of view the developer that uses the library should be able to use all the sizes available from Tailwind CSS (from `size-0` all the way up to `size-96`), either by changing the class of the root element or using a `size` prop.

### Roadmap
- firstly test each component, one by one, to check if this is applicable to all of them
- define what to do for those components that aren't square and have different `width`s and `height`s (which one should be controlled? should it depend on component type?)
- define how to handle nested components (both from the library and user's created)